### PR TITLE
debug of mk20s removed - sorry

### DIFF
--- a/weapons.txt
+++ b/weapons.txt
@@ -392,7 +392,7 @@ SensorAngles=60,15
 SensorRange=1250
 WeaponNoiseValues=120,120
 MaxPitchAngle=25
-HomeSettings=PASSIVE,ACTIVE
+HomeSettings=PASSIVE
 AttackSettings=STRAIGHT,SNAKE,LEFT,RIGHT
 DepthSettings=LEVEL,SHALLOW,DEEP
 MinCameraDistance=0.5
@@ -417,12 +417,6 @@ AudioRollOff=LOGARITHMIC
 AudioDistance=1,25
 AudioPitch=1
 AudioLoop=TRUE
-AudioSource=TorpedoSonarPing
-AudioClip=audio/environment/sonar_ping_short
-AudioRollOff=LOGARITHMIC
-AudioDistance=1,25
-AudioPitch=1.2
-AudioLoop=FALSE;
 [/Model]
 
 WeaponObjectReference=uk_mk8


### PR DESCRIPTION
while debugging the mk20s for the aiming circle missing, I had added the active sonar, just to find out that it wasn't that but the ordering instead. in previous upload (few minutes ago) I had left the active sonar on. now removed and back to original ramius source - sorry again