### PR TITLE
Updated US Navy Ships and helos sensors

### DIFF
--- a/override/aircraft.txt
+++ b/override/aircraft.txt
@@ -189,7 +189,7 @@ AudioDistance=0.1,16
 AudioPitch=1
 [/Model]
 
-// SH60B Helicopter
+// SH60B Helicopter - 80s
 AircraftObjectReference=usn_sh60b
 AircraftType=HELICOPTER
 CruiseSpeed=106
@@ -202,7 +202,7 @@ RADARSignature=SMALL
 //SH60B does not have dipping sonar, added SH3D dipping for gameplay since sonobuoys are dropped sporadically
 ActiveSonarModel=usn_an_aqs-13
 PassiveSonarModel=usn_an_aqs-13
-SonobuoyTypes=usn_asb,usn_psb
+SonobuoyTypes=usn_ssq62,usn_ssq53b
 SonobuoyNumbers=13,13
 [Weapon Systems]
 TorpedoTypes=usn_mk46
@@ -238,7 +238,7 @@ AudioDistance=0.1,16
 AudioPitch=1
 [/Model]
 
-// SH60F Helicopter
+// SH60F Helicopter - Late 90s
 AircraftObjectReference=usn_sh60f
 AircraftType=HELICOPTER
 CruiseSpeed=106
@@ -250,7 +250,7 @@ RADAR=usn_aps-124
 RADARSignature=SMALL
 ActiveSonarModel=usn_an_aqs-13f
 PassiveSonarModel=usn_an_aqs-13f
-SonobuoyTypes=usn_asb,usn_psb
+SonobuoyTypes=usn_ssq62,usn_ssq53b
 SonobuoyNumbers=13,13
 [Weapon Systems]
 TorpedoTypes=usn_mk50
@@ -286,7 +286,7 @@ AudioDistance=0.1,16
 AudioPitch=1
 [/Model]
 
-// SH2 Helicopter
+// SH2 Helicopter - Late 60s
 AircraftObjectReference=usn_sh2f
 AircraftType=HELICOPTER
 CruiseSpeed=106
@@ -299,8 +299,8 @@ RADARSignature=SMALL
 //SH60B does not have dipping sonar, added SH3D dipping for gameplay since sonobuoys are dropped sporadically
 ActiveSonarModel=usn_an_aqs-13
 PassiveSonarModel=usn_an_aqs-13
-SonobuoyTypes=usn_asb,usn_psb
-SonobuoyNumbers=13,13
+SonobuoyTypes=usn_ssq47,usn_ssq38,usn_ssq53a
+SonobuoyNumbers=13,7,7
 [Weapon Systems]
 TorpedoTypes=usn_mk46_early
 TorpedoNumbers=2
@@ -335,7 +335,7 @@ AudioDistance=0.1,16
 AudioPitch=1
 [/Model]
 
-// SH3D Helicopter
+// SH3D Helicopter - Late 60s
 AircraftObjectReference=usn_sh3d
 AircraftType=HELICOPTER
 CruiseSpeed=106
@@ -347,10 +347,107 @@ RADAR=usn_aps-124
 RADARSignature=SMALL
 ActiveSonarModel=usn_an_aqs-13
 PassiveSonarModel=usn_an_aqs-13
-SonobuoyTypes=usn_asb,usn_psb
-SonobuoyNumbers=10,10
+SonobuoyTypes=usn_ssq47,usn_ssq38,usn_ssq53a
+SonobuoyNumbers=10,5,5
 [Weapon Systems]
 TorpedoTypes=usn_mk46_early
+TorpedoNumbers=2
+DepthBomb=usn_depth_bomb
+DepthBombNumbers=4
+MinCameraDistance=0.5
+
+[Model]
+ModelFile=aircraft/wp_helix/wp_helix
+MeshPosition=0,0,0
+MeshRotation=0,0,0
+Material=aircraft/wp_helix/wp_helix_mat
+MaterialTextures=aircraft/wp_helix/wp_helix_tx,aircraft/wp_helix/wp_helix_spec,aircraft/wp_helix/wp_helix_nm
+MeshAircraftBody=wp_helix
+DippingSonarPosition=0,-0.022,-0.05
+
+MeshPosition=0,0.03723,0
+Material=aircraft/materials/prop_3_blade
+MeshSpeed=-100
+MeshAircraftProp=Rotor_CCW
+
+MeshPosition=0,0.0104,0
+Material=aircraft/materials/prop_3_blade
+MeshSpeed=100
+MeshAircraftProp=Rotor_CW
+
+HoverParticle=aircraft/heli_hover
+
+AudioClip=audio/units/ka25_inflight
+AudioRollOff=LINEAR
+AudioDistance=0.1,16
+AudioPitch=1
+[/Model]
+
+// SH2 Helicopter - 80s
+AircraftObjectReference=usn_sh2f_late
+AircraftType=HELICOPTER
+CruiseSpeed=106
+Length=12.2
+Height=4.7
+Weight=5805
+Crew=4
+RADAR=usn_aps-124
+RADARSignature=SMALL
+//SH60B does not have dipping sonar, added SH3D dipping for gameplay since sonobuoys are dropped sporadically
+ActiveSonarModel=usn_an_aqs-13
+PassiveSonarModel=usn_an_aqs-13
+SonobuoyTypes=usn_ssq62,usn_ssq53b
+SonobuoyNumbers=13,13
+[Weapon Systems]
+TorpedoTypes=usn_mk46
+TorpedoNumbers=2
+DepthBomb=usn_depth_bomb
+DepthBombNumbers=2
+MinCameraDistance=0.5
+
+[Model]
+ModelFile=aircraft/wp_helix/wp_helix
+MeshPosition=0,0,0
+MeshRotation=0,0,0
+Material=aircraft/wp_helix/wp_helix_mat
+MaterialTextures=aircraft/wp_helix/wp_helix_tx,aircraft/wp_helix/wp_helix_spec,aircraft/wp_helix/wp_helix_nm
+MeshAircraftBody=wp_helix
+DippingSonarPosition=0,-0.022,-0.05
+
+MeshPosition=0,0.03723,0
+Material=aircraft/materials/prop_3_blade
+MeshSpeed=-100
+MeshAircraftProp=Rotor_CCW
+
+MeshPosition=0,0.0104,0
+Material=aircraft/materials/prop_3_blade
+MeshSpeed=100
+MeshAircraftProp=Rotor_CW
+
+HoverParticle=aircraft/heli_hover
+
+AudioClip=audio/units/ka25_inflight
+AudioRollOff=LINEAR
+AudioDistance=0.1,16
+AudioPitch=1
+[/Model]
+
+// SH3D Helicopter - 80s
+AircraftObjectReference=usn_sh3d_late
+AircraftType=HELICOPTER
+CruiseSpeed=106
+Length=16.7
+Height=5.13
+Weight=10000
+Crew=4
+RADAR=usn_aps-124
+RADARSignature=SMALL
+ActiveSonarModel=usn_an_aqs-13
+PassiveSonarModel=usn_an_aqs-13
+SonobuoyTypes=usn_ssq62,usn_ssq53b
+SonobuoyNumbers=10,10
+[Weapon Systems]
+TorpedoTypes=usn_mk46
 TorpedoNumbers=2
 DepthBomb=usn_depth_bomb
 DepthBombNumbers=4
@@ -531,8 +628,8 @@ RADARSignature=LARGE
 ActiveSonarModel=FALSE
 PassiveSonarModel=FALSE
 
-SonobuoyTypes=usn_asb,usn_psb
-SonobuoyNumbers=16,9
+SonobuoyTypes=usn_ssq47,usn_ssq38,usn_ssq53a
+SonobuoyNumbers=16,5,5
 
 
 [Weapon Systems]
@@ -591,8 +688,8 @@ RADARSignature=LARGE
 ActiveSonarModel=FALSE
 PassiveSonarModel=FALSE
 
-SonobuoyTypes=usn_asb,usn_psb
-SonobuoyNumbers=16,9
+SonobuoyTypes=usn_ssq62,usn_ssq53b
+SonobuoyNumbers=16,10
 
 
 [Weapon Systems]

--- a/override/language_en/aircraft/usn_sh2f_late_description.txt
+++ b/override/language_en/aircraft/usn_sh2f_late_description.txt
@@ -1,0 +1,4 @@
+[Unit Reference]
+AircraftName=SH-2 Seasprite (80s version)
+AircraftDescriptiveName=SH-2 Seasprite (80s version)
+History=The Kaman SH-2 Seasprite is a ship-based helicopter originally developed in the late 1950s as a fast utility helicopter for the United States Navy. In the 1970s, anti-submarine, anti-surface threat capabilities were added to the design, including over-the-horizon targeting, resulting in modifying most existing UH-2 models to the SH-2 Seasprite.

--- a/override/language_en/aircraft/usn_sh3d_late_description.txt
+++ b/override/language_en/aircraft/usn_sh3d_late_description.txt
@@ -1,0 +1,4 @@
+[Unit Reference]
+AircraftName=SH-3 D Sea King (80s version)
+AircraftDescriptiveName=SH-3 D Sea King (80s version)
+History=The Sikorsky SH-3 Sea King (company designation S-61) is an American twin-engined anti-submarine warfare (ASW) helicopter designed and built by Sikorsky Aircraft. A landmark design, it was the world's first amphibious helicopter and one of the first ASW rotorcraft to use turboshaft engines.

--- a/override/language_en/sensor/sensor_display_names.txt
+++ b/override/language_en/sensor/sensor_display_names.txt
@@ -172,9 +172,15 @@ wp_bm_3=BM-3=RGB-3 'Snipe Egg 3' active/passive sonobuoy.
 
 //USN SONOBUOYS
 
-usn_asb=ASB=Active sonobuoys emit sound energy (pings) into the water and listen for the returning echo before transmitting information—usually range and bearing—via UHF/VHF radio to a receiving ship or aircraft. The original active sonobuoys pinged continuously after deployment for a predetermined period of time. Later, Command Activated Sonobuoy System (CASS) sonobuoys allowed the aircraft to trigger pings (or buoy scuttling) via a radio link. This evolved into DICASS (Directional CASS) in which the return echo contained bearing as well as range data.
+usn_ssq62=AN/SSQ-62= USN active sonobuoy DICASS AN/SSQ-62 - In service since late 70s.
 
-usn_psb=PSB=Passive sonobuoys emit nothing into the water, but rather listen, waiting for sound waves (for instance, power plant, propeller or door-closing and other noises) from ships or submarines, or other acoustic signals of interest such as an aircraft's black box pinger, to reach the hydrophone. The sound is then transmitted via UHF/VHF radio to a receiving ship or aircraft.
+usn_ssq47=AN/SSQ-47= USN active sonobuoy CASS AN/SSQ-47 - In service since late 60s.
+
+usn_ssq38=AN/SSQ-38= USN passive sonobuoy LOFAR AN/SSQ-38 - In service during the 60s.
+
+usn_ssq53a=AN/SSQ-53A= USN passive sonobuoy DIFAR AN/SSQ-53A - In service since the late 60s.
+
+usn_ssq53b=AN/SSQ-53B= USN passive sonobuoy DIFAR AN/SSQ-53B - In service since the mid 80s.
 
 //WP HELO DIPPING SONARS
 

--- a/override/sensors.txt
+++ b/override/sensors.txt
@@ -422,7 +422,7 @@ SonarModel=usn_an_sqs-56
 SonarType=ACTIVE/PASSIVE
 SonarFrequencies=L,M
 SonarActiveSensitivity=34
-SonarPassiveSensitivity=38
+SonarPassiveSensitivity=34
 SonarBaffle=150
 SonarNoisePerKnot=1
 SonarOutput=220
@@ -440,7 +440,7 @@ SonarModel=usn_an_sqr-19
 SonarType=TOWED
 SonarFrequencies=VL,L
 SonarActiveSensitivity=0
-SonarPassiveSensitivity=44
+SonarPassiveSensitivity=46
 SonarBaffle=FALSE
 SonarNoisePerKnot=2
 SonarOutput=0
@@ -449,7 +449,7 @@ SonarModel=usn_an_sqs-26
 SonarType=ACTIVE/PASSIVE
 SonarFrequencies=L,M
 SonarActiveSensitivity=32
-SonarPassiveSensitivity=36
+SonarPassiveSensitivity=38
 SonarBaffle=150
 SonarNoisePerKnot=1
 SonarOutput=220
@@ -457,8 +457,8 @@ SonarOutput=220
 SonarModel=usn_an_sqs-23
 SonarType=ACTIVE/PASSIVE
 SonarFrequencies=L,M
-SonarActiveSensitivity=30
-SonarPassiveSensitivity=32
+SonarActiveSensitivity=32
+SonarPassiveSensitivity=36
 SonarBaffle=150
 SonarNoisePerKnot=1
 SonarOutput=220
@@ -779,8 +779,18 @@ SonarBaffle=FALSE
 SonarNoisePerKnot=0
 SonarOutput=200
 
-// USN active sonobuoy
-SonarModel=usn_asb
+// USN active sonobuoy DICASS AN/SSQ-62 - Late 70s
+SonarModel=usn_ssq62
+SonarType=SONOBUOY
+SonarFrequencies=M
+SonarActiveSensitivity=28
+SonarPassiveSensitivity=0
+SonarBaffle=FALSE
+SonarNoisePerKnot=0
+SonarOutput=200
+
+// USN active sonobuoy CASS AN/SSQ-47 - Late 60s
+SonarModel=usn_ssq47
 SonarType=SONOBUOY
 SonarFrequencies=M
 SonarActiveSensitivity=21
@@ -789,12 +799,32 @@ SonarBaffle=FALSE
 SonarNoisePerKnot=0
 SonarOutput=200
 
-// USN passive sonobuoy
-SonarModel=usn_psb
+// USN passive sonobuoy LOFAR AN/SSQ-38 - 60s
+SonarModel=usn_ssq38
 SonarType=SONOBUOY
 SonarFrequencies=M
 SonarActiveSensitivity=0
-SonarPassiveSensitivity=30
+SonarPassiveSensitivity=25
+SonarBaffle=FALSE
+SonarNoisePerKnot=0
+SonarOutput=0
+
+// USN passive sonobuoy DIFAR AN/SSQ-53A - Late 60s
+SonarModel=usn_ssq53a
+SonarType=SONOBUOY
+SonarFrequencies=M
+SonarActiveSensitivity=0
+SonarPassiveSensitivity=28
+SonarBaffle=FALSE
+SonarNoisePerKnot=0
+SonarOutput=0
+
+// USN passive sonobuoy DIFAR AN/SSQ-53B - Mid 80s
+SonarModel=usn_ssq53b
+SonarType=SONOBUOY
+SonarFrequencies=M
+SonarActiveSensitivity=0
+SonarPassiveSensitivity=32
 SonarBaffle=FALSE
 SonarNoisePerKnot=0
 SonarOutput=0

--- a/override/vessels/usn_bpk_belknap_late.txt
+++ b/override/vessels/usn_bpk_belknap_late.txt
@@ -9,7 +9,7 @@ Crew=477
 Range=10500
 HullNumbers=FALSE
 AircraftNumbers=1
-AircraftTypes=usn_sh2f
+AircraftTypes=usn_sh2f_late
 
 [Movement]
 SurfaceSpeed=32

--- a/override/vessels/usn_bpk_knox.txt
+++ b/override/vessels/usn_bpk_knox.txt
@@ -9,7 +9,7 @@ Crew=257
 Range=4500
 HullNumbers=FALSE
 AircraftNumbers=1
-AircraftTypes=usn_sh2f
+AircraftTypes=usn_sh3d_late
 
 [Movement]
 SurfaceSpeed=27

--- a/override/vessels/usn_kr_iowa_late.txt
+++ b/override/vessels/usn_kr_iowa_late.txt
@@ -9,7 +9,7 @@ Crew=1800
 Range=14900
 HullNumbers=FALSE
 AircraftNumbers=3
-AircraftTypes=usn_sh3d
+AircraftTypes=usn_sh60b
 
 [Movement]
 SurfaceSpeed=32

--- a/override/vessels/usn_takr_nimitz.txt
+++ b/override/vessels/usn_takr_nimitz.txt
@@ -8,8 +8,8 @@ Displacement=100000
 Crew=5680
 Range=20000
 HullNumbers=FALSE
-AircraftNumbers=4
-AircraftTypes=usn_sh60b
+AircraftNumbers=4,2
+AircraftTypes=usn_sh60b,usn_sh3d_late
 
 [Movement]
 SurfaceSpeed=30


### PR DESCRIPTION
Updated the sensors AN/SQS53, AN/SQS56, AN/SQS23, AN/SQS26, AN/SQR19 sensitivity using as base the range data published in CMANO.
Also completely updated US Navy sonobuoys, introducing CASS, DICASS, LOFAR and DIFAR for time period from 60s to late 80s.
Updated as consequence the US Navy helos sonobuoy loadout.
Split the SH2F and SH3D in early and late variant, the difference being the torpedo loadout (Mk46 early or late variant) and sonobuoy loadout.