### PR TITLE
Damage Decal fixes

### DIFF
--- a/Default UI/plan_ss_kilo.txt
+++ b/Default UI/plan_ss_kilo.txt
@@ -168,6 +168,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ss_kilo/wp_ss_kilo
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub

--- a/Default UI/plan_ss_ming.txt
+++ b/Default UI/plan_ss_ming.txt
@@ -181,6 +181,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/plan_ss_ming/plan_ss_ming
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/Default UI/plan_ss_romeo.txt
+++ b/Default UI/plan_ss_romeo.txt
@@ -180,6 +180,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/plan_ss_romeo/plan_ss_romeo
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/Default UI/wp_ssb_golf.txt
+++ b/Default UI/wp_ssb_golf.txt
@@ -177,6 +177,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssb_golf/wp_ssb_golf
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/Default UI/wp_ssbn_borei.txt
+++ b/Default UI/wp_ssbn_borei.txt
@@ -421,7 +421,7 @@ MeshNoisemakerMount=FALSE
 
 
 MeshPosition=0,0,0
-ModelFile=ships/wp_ssbn_delta4/wp_ssbn_delta4
+ModelFile=ships/wp_ssbn_yankee/wp_ssbn_yankee
 
 
 //Wake

--- a/Default UI/wp_ssn_akula1.txt
+++ b/Default UI/wp_ssn_akula1.txt
@@ -182,6 +182,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssn_akula1/wp_ssn_akula1
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub

--- a/Default UI/wp_ssn_akula2.txt
+++ b/Default UI/wp_ssn_akula2.txt
@@ -193,6 +193,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssn_akula1/wp_ssn_akula1
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub

--- a/override/vessels/fra_ssbn_triomphant.txt
+++ b/override/vessels/fra_ssbn_triomphant.txt
@@ -423,6 +423,8 @@ MeshPosition=0.03,0.0002,-0.800
 MeshRotation=6,12,0
 Mesh=Mk37
 
+MeshPosition=0,0,0
+ModelFile=ships/usn_ssn_los_angeles/usn_ssn_los_angeles
 
 //Wake
 MeshPosition=0,0,-0.6496

--- a/override/vessels/plan_ss_kilo.txt
+++ b/override/vessels/plan_ss_kilo.txt
@@ -168,6 +168,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ss_kilo/wp_ss_kilo
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub

--- a/override/vessels/plan_ss_ming.txt
+++ b/override/vessels/plan_ss_ming.txt
@@ -181,6 +181,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/plan_ss_ming/plan_ss_ming
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/override/vessels/plan_ss_romeo.txt
+++ b/override/vessels/plan_ss_romeo.txt
@@ -180,6 +180,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/plan_ss_romeo/plan_ss_romeo
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/override/vessels/wp_ssb_golf.txt
+++ b/override/vessels/wp_ssb_golf.txt
@@ -177,6 +177,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssb_golf/wp_ssb_golf
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_small

--- a/override/vessels/wp_ssbn_borei.txt
+++ b/override/vessels/wp_ssbn_borei.txt
@@ -421,7 +421,7 @@ MeshNoisemakerMount=FALSE
 
 
 MeshPosition=0,0,0
-ModelFile=ships/wp_ssbn_delta4/wp_ssbn_delta4
+ModelFile=ships/wp_ssbn_yankee/wp_ssbn_yankee
 
 
 //Wake

--- a/override/vessels/wp_ssn_akula1.txt
+++ b/override/vessels/wp_ssn_akula1.txt
@@ -182,6 +182,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssn_akula1/wp_ssn_akula1
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub

--- a/override/vessels/wp_ssn_akula2.txt
+++ b/override/vessels/wp_ssn_akula2.txt
@@ -193,6 +193,9 @@ MeshRotation=0,0,0
 MeshPosition=0,-0.056,-0.533
 MeshNoisemakerMount=FALSE
 
+MeshPosition=0,0,0
+ModelFile=ships/wp_ssn_akula1/wp_ssn_akula1
+
 //Wake
 MeshPosition=0,0,0
 BowWaveParticle=ships/particles/bowwave_sub


### PR DESCRIPTION
PLAN Kilo, Ming and Romeo (both)
WP Golf, Borei, Akula I and II (both)
FRA Triomphant (not default - as it is already)