### PR TITLE
Fix for campaign map symbol colours

### DIFF
--- a/override/campaign/campaign007/language_en/campaign_map_data.txt
+++ b/override/campaign/campaign007/language_en/campaign_map_data.txt
@@ -72,9 +72,13 @@ LabelPosition=354,-230.2
 LabelName=Leningrad
 
 [MARKERS]
-Color=255,255,255,255
+Color=0,255,0,255
 Outline=TRUE
 Size=10
+LocationMarkerPosition=358,32.7
+Color=255,255,255,255
+Outline=TRUE
+Size=5
 LocationMarkerPosition=-204.16,-185.34
 LocationMarkerPosition=-142.37,-37.5
 LocationMarkerPosition=-254.81,130.94

--- a/override/campaign/campaign008/language_en/campaign_map_data.txt
+++ b/override/campaign/campaign008/language_en/campaign_map_data.txt
@@ -72,9 +72,13 @@ LabelPosition=354,-230.2
 LabelName=Leningrad
 
 [MARKERS]
-Color=255,255,255,255
+Color=0,255,0,255
 Outline=TRUE
 Size=10
+LocationMarkerPosition=358,32.7
+Color=255,255,255,255
+Outline=TRUE
+Size=5
 LocationMarkerPosition=-204.16,-185.34
 LocationMarkerPosition=-142.37,-37.5
 LocationMarkerPosition=-254.81,130.94

--- a/override/campaign/campaign009/language_en/campaign_map_data.txt
+++ b/override/campaign/campaign009/language_en/campaign_map_data.txt
@@ -72,9 +72,13 @@ LabelPosition=354,-230.2
 LabelName=Leningrad
 
 [MARKERS]
-Color=255,255,255,255
+Color=0,255,0,255
 Outline=TRUE
 Size=10
+LocationMarkerPosition=358,32.7
+Color=255,255,255,255
+Outline=TRUE
+Size=5
 LocationMarkerPosition=-204.16,-185.34
 LocationMarkerPosition=-142.37,-37.5
 LocationMarkerPosition=-254.81,130.94


### PR DESCRIPTION
Fix on Campaign 007, 008 and 009 for Green start location.