### PR TITLE
Shortened description, fixed spelling

### DIFF
--- a/override/language_en/weapon/wp_53-65M_description.txt
+++ b/override/language_en/weapon/wp_53-65M_description.txt
@@ -1,4 +1,4 @@
 [Weapon Reference]
 WeaponName=53-65M
 WeaponDescriptiveName=53-65M Torpedo
-WeaponDescription=The 53-65 torpedo family are Russian made, wake-homing torpedoes designed to destroy surface ships. The 53-65 became operational in 1965, while the 53-65K and 53-65M both became operational in 1969. The 53-65KE is an exported version. China received an unknown number of 53-65KE torpedoes from Russia after purchasing 4 Kilo class submarines in the 1990s.In came it is simulated as conventional passive homing torpedo.
+WeaponDescription=The 53-65 torpedo family are Russian made wake-homing torpedoes designed to destroy surface ships. In game it is modelled as conventional passive homing torpedo.


### PR DESCRIPTION
There was a short summary detailing history and exports of this torpedo. I do not believe that it is necessary to include this information. Removal of this section also brings the description to be more in line with other weapon descriptions.